### PR TITLE
fix: 支持HTTP协议调用API服务

### DIFF
--- a/src/aiService.ts
+++ b/src/aiService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as https from 'https';
+import * as http from http;
 
 /**
  * AI服务类，用于生成SVN提交日志
@@ -474,7 +475,8 @@ ${truncatedDiff}
         }
       };
 
-      const req = https.request(options, (res) => {
+      const requestModule = url.protocol === 'https:' ? https : http;
+      const req = requestModule.request(options, (res) => {
         let data = '';
         
         res.on('data', (chunk) => {


### PR DESCRIPTION
本次提交修复了API调用仅支持HTTPS协议的问题，修改API调用逻辑，根据URL协议自动选择http/https模块