### PR TITLE
fix: 适配通义千问 DashScope 原生接口 + 文件夹面板支持双击对比 (closes #13, #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 更新日志
 
+## [4.10.1] - 2026-05-07
+
+### 🐛 Bug 修复
+
+- **修复通义千问 DashScope 原生接口报错（关闭 issue #13）**
+  - 错误信息：`Either "prompt" or "messages" must exist and cannot both be none`
+  - 原因：插件统一使用 OpenAI Chat Completions 格式，而 DashScope 原生 `/api/v1/services/aigc/text-generation/generation` 需要 `input.messages + parameters` 格式
+  - 现在自动检测 URL，DashScope 原生接口自动转换请求体并解析 `output.choices[0].message.content` / `output.text` 两种返回格式
+  - 配置说明同步更新，推荐用户使用百炼兼容模式接口 `https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`
+
+### ✨ 体验优化
+
+- **文件夹提交面板支持双击打开差异对比（关闭 issue #11）**
+  - 原来需要先在左侧找到文件再把鼠标移到右侧按钮，文件多时操作不便
+  - 现在在文件项任意空白处双击即可直接打开差异对比
+  - 自动避开 checkbox、操作按钮等交互元素，避免误触
+  - 鼠标悬停提示"双击打开差异对比"
+
 ## [4.10.0] - 2026-05-07
 
 ### ✨ 新增 SVN 文件锁定/解锁功能（关闭 issue #14）

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-svn-ai",
   "displayName": "VSCode SVN - AI智能版本控制",
   "description": "🚀 全平台SVN智能插件：基于原生命令行工具，支持Windows/macOS/Linux，内置AI提交日志生成，可视化差异对比，100%开源透明。无需TortoiseSVN，轻量级高性能！",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "publisher": "pengfeiSummer",
   "icon": "resources/icon.png",
   "engines": {

--- a/src/aiService.ts
+++ b/src/aiService.ts
@@ -179,10 +179,15 @@ export class AiService {
    • 模型ID: gpt-3.5-turbo 或 gpt-4
    • API密钥: sk-...（从OpenAI官网获取）
 
-🔹 通义千问
+🔹 通义千问（推荐使用兼容模式）
+   • API地址: https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+   • 模型ID: qwen-turbo / qwen-plus / qwen-max
+   • API密钥: sk-...（从阿里云百炼控制台获取）
+
+🔹 通义千问（原生接口，已自动适配）
    • API地址: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
    • 模型ID: qwen-turbo 或 qwen-plus
-   • API密钥: sk-...（从阿里云控制台获取）
+   • API密钥: sk-...
 
 🔹 文心一言
    • API地址: https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions
@@ -442,27 +447,72 @@ ${truncatedDiff}
    * @param config AI配置
    * @returns AI生成的回复
    */
+  /**
+   * 判断是否为 DashScope（阿里云通义千问）原生接口
+   * 原生接口路径形如：/api/v1/services/aigc/text-generation/generation
+   * 兼容模式接口（compatible-mode）使用标准 OpenAI 格式，不在此列
+   */
+  private isDashScopeNativeApi(apiUrl: string): boolean {
+    try {
+      const url = new URL(apiUrl);
+      const host = url.hostname.toLowerCase();
+      const pathname = url.pathname.toLowerCase();
+      const isDashScopeHost = host.endsWith('dashscope.aliyuncs.com') || host.endsWith('dashscope-intl.aliyuncs.com');
+      if (!isDashScopeHost) {
+        return false;
+      }
+      // compatible-mode 走标准 OpenAI 格式
+      if (pathname.includes('/compatible-mode/')) {
+        return false;
+      }
+      // 原生 aigc 接口（包括 text-generation、multimodal-generation 等）
+      return pathname.includes('/services/aigc/') || pathname.endsWith('/generation');
+    } catch {
+      return false;
+    }
+  }
+
   private callAiApi(prompt: string, config: { apiUrl: string; modelId: string; apiKey: string }): Promise<string> {
     return new Promise((resolve, reject) => {
-      // 构建请求数据 - 使用通用的OpenAI格式
-      const requestData = JSON.stringify({
-        model: config.modelId,
-        messages: [
-          {
-            role: 'system',
-            content: '你是一个专业的代码提交信息生成助手。请根据提供的代码差异生成简洁、准确的中文提交信息。'
-          },
-          {
-            role: 'user',
-            content: prompt
-          }
-        ],
-        temperature: 0.7,
-        max_tokens: 2000
-      });
-
-      // 解析URL
+      // 解析URL，根据接口类型选择请求体格式
       const url = new URL(config.apiUrl);
+      const isDashScopeNative = this.isDashScopeNativeApi(config.apiUrl);
+
+      // 系统消息 / 用户消息
+      const systemPrompt = '你是一个专业的代码提交信息生成助手。请根据提供的代码差异生成简洁、准确的中文提交信息。';
+
+      // 构建请求体：
+      // - DashScope 原生接口（/api/v1/services/aigc/text-generation/generation）使用 input.messages + parameters 格式
+      // - 其它（OpenAI 兼容、百炼 compatible-mode、文心、OpenAI、deepseek 等）使用 OpenAI Chat Completions 格式
+      let requestData: string;
+      if (isDashScopeNative) {
+        requestData = JSON.stringify({
+          model: config.modelId,
+          input: {
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: prompt }
+            ]
+          },
+          parameters: {
+            temperature: 0.7,
+            max_tokens: 2000,
+            result_format: 'message'
+          }
+        });
+        this.outputChannel.appendLine('[callAiApi] 检测到 DashScope 原生接口，使用 input.messages 请求格式');
+      } else {
+        requestData = JSON.stringify({
+          model: config.modelId,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: prompt }
+          ],
+          temperature: 0.7,
+          max_tokens: 2000
+        });
+      }
+
       const options = {
         hostname: url.hostname,
         port: url.port || (url.protocol === 'https:' ? 443 : 80),
@@ -491,14 +541,18 @@ ${truncatedDiff}
               // 尝试解析不同格式的响应
               let content = '';
               if (response.choices && response.choices[0] && response.choices[0].message) {
-                // OpenAI格式
-                content = response.choices[0].message.content.trim();
-              } else if (response.output && response.output.text) {
-                // 通义千问格式
+                // OpenAI Chat Completions 格式（OpenAI、百炼 compatible-mode、deepseek 等）
+                content = (response.choices[0].message.content || '').trim();
+              } else if (response.output && response.output.choices && response.output.choices[0] &&
+                         response.output.choices[0].message) {
+                // DashScope 原生接口 + result_format=message 格式
+                content = (response.output.choices[0].message.content || '').trim();
+              } else if (response.output && typeof response.output.text === 'string') {
+                // DashScope 原生接口 + 默认 text 格式
                 content = response.output.text.trim();
               } else if (response.result) {
-                // 其他可能的格式
-                content = response.result.trim();
+                // 其它可能的格式（如部分代理）
+                content = (typeof response.result === 'string' ? response.result : JSON.stringify(response.result)).trim();
               } else {
                 throw new Error('无法解析AI响应格式');
               }

--- a/src/templates/folderCommitPanel.js
+++ b/src/templates/folderCommitPanel.js
@@ -90,6 +90,27 @@
                     revertFile(filePath);
                 });
             }
+
+            // 双击文件项快速打开差异对比（issue #11）
+            // 排除 checkbox / 操作按钮 / 链接等交互元素，避免误触发
+            item.addEventListener('dblclick', (e) => {
+                const target = e.target;
+                if (target && target.closest && target.closest(
+                    '.file-checkbox, .diff-button, .side-by-side-button, .revert-button, button, a, input'
+                )) {
+                    return;
+                }
+                // 防止双击选中文本造成视觉干扰
+                if (window.getSelection) {
+                    const sel = window.getSelection();
+                    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+                }
+                showDiff(filePath);
+            });
+
+            // 视觉提示：鼠标悬停时显示可双击
+            item.style.cursor = item.style.cursor || 'default';
+            item.title = item.title || '双击打开差异对比';
         });
     }
     

--- a/templates/folderCommitPanel.js
+++ b/templates/folderCommitPanel.js
@@ -90,6 +90,27 @@
                     revertFile(filePath);
                 });
             }
+
+            // 双击文件项快速打开差异对比（issue #11）
+            // 排除 checkbox / 操作按钮 / 链接等交互元素，避免误触发
+            item.addEventListener('dblclick', (e) => {
+                const target = e.target;
+                if (target && target.closest && target.closest(
+                    '.file-checkbox, .diff-button, .side-by-side-button, .revert-button, button, a, input'
+                )) {
+                    return;
+                }
+                // 防止双击选中文本造成视觉干扰
+                if (window.getSelection) {
+                    const sel = window.getSelection();
+                    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+                }
+                showDiff(filePath);
+            });
+
+            // 视觉提示：鼠标悬停时显示可双击
+            item.style.cursor = item.style.cursor || 'default';
+            item.title = item.title || '双击打开差异对比';
         });
     }
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 关联 issue

- closes #13 — 配置通义千问调用报错（prompt/messages 没有传值）
- closes #11 — 希望提交时双击文件打开对比界面

---

## #13 通义千问 DashScope 原生接口适配

### 报错

```
AI API调用失败: 400 - {"request_id":"...","code":"InvalidParameter",
"message":"Either \"prompt\" or \"messages\" must exist and cannot both be none"}
```

### 根因

插件之前统一使用 OpenAI Chat Completions 请求体（顶层 `messages`），但用户配置的是 **DashScope 原生接口**：

```
https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
```

该接口要求的请求格式是：

```json
{
  "model": "qwen-plus",
  "input": { "messages": [...] },
  "parameters": { "temperature": 0.7, "max_tokens": 2000, "result_format": "message" }
}
```

### 修复（`src/aiService.ts`）

1. 新增 `isDashScopeNativeApi(url)`：根据域名 + 路径判断是否为 DashScope 原生接口
   - `dashscope.aliyuncs.com` / `dashscope-intl.aliyuncs.com` 域名
   - 路径包含 `/services/aigc/` 或以 `/generation` 结尾
   - `compatible-mode` 路径排除（按 OpenAI 标准格式发）
2. `callAiApi` 根据判断结果选择请求体格式
3. 响应解析新增对 `output.choices[0].message.content`、`output.text` 两种 DashScope 返回的支持
4. 配置说明同步更新，推荐使用百炼**兼容模式**：
   - `https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`

---

## #11 文件夹提交面板支持双击对比

### 现状

文件多时需要先找到文件名，再把视线挪到右侧按钮再点击，效率低。

### 修复（`src/templates/folderCommitPanel.js`）

- 在 `initializeFileItemEvents` 中给每个 `.file-item` 加 `dblclick` 监听 → 触发现有 `showDiff(filePath)`
- 自动排除 `checkbox / 操作按钮 / 链接 / input` 等交互元素，避免误触发
- 双击前清空文本选区，避免视觉干扰
- 鼠标悬停 `title="双击打开差异对比"` 作为提示

---

## 验证

- `npm run compile` 通过
- DashScope 兼容模式 URL 不会被误判为原生接口（仍走 OpenAI 格式）
- `compatible-mode/v1/chat/completions` 走 OpenAI 格式（自检通过）
- DashScope 原生 URL 走新格式（请求体 / 响应解析均覆盖）

## 兼容性

- OpenAI、deepseek、百炼兼容模式、文心等其它接口完全不受影响
- 仅 DashScope 原生接口自动切换到正确格式

版本：`4.10.0` → `4.10.1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67dd9daf-63f8-4d97-a8b5-eec982dadd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67dd9daf-63f8-4d97-a8b5-eec982dadd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

